### PR TITLE
Use link from response as dashboard link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,3 @@ USER_ENDPOINT_URL=http://localhost:8080/user.json
 
 # The endpoint to send data to on device registration
 PROVISION_ENDPOINT_URL=http://localhost:8080/provision.json
-
-# The endpoint of the OpenEEW dashboard
-DASHBOARD_URL=http://localhost:8080/dashboard.html

--- a/lib/forms/complete.dart
+++ b/lib/forms/complete.dart
@@ -13,19 +13,23 @@ import 'package:openeew_provisioner/operations/perform_url_route.dart';
 import 'package:openeew_provisioner/screens/steps.dart';
 
 class CompleteForm extends StatefulWidget {
-  CompleteForm({ Key key }) : super(key: key);
+  final Map state;
+
+  CompleteForm({ Key key, this.state }) : super(key: key);
 
   @override
   CompleteFormState createState() {
-    return CompleteFormState();
+    return CompleteFormState(state);
   }
 }
 
 class CompleteFormState extends State<CompleteForm> {
+  final Map state;
+
+  CompleteFormState(this.state);
+
   void submit(BuildContext context) async {
-    await PerformUrlRoute({
-      'url': DotEnv().env['DASHBOARD_URL']
-    }).perform();
+    await PerformUrlRoute({ 'link': this.state['link'] }).perform();
   }
 
   void restart(BuildContext context) async {

--- a/lib/operations/perform_provision_request.dart
+++ b/lib/operations/perform_provision_request.dart
@@ -21,7 +21,14 @@ class PerformProvisionRequest extends AsyncPlatformOperation {
   Future<int> fallback() async {
     var response = await http.post(
       DotEnv().env['PROVISION_ENDPOINT_URL'],
-      body: jsonEncode(this.args['state'])
+      body: jsonEncode({
+        'userId': this.args['state']['user_id'],
+        'macaddress': this.args['state']['macaddress'],
+        'latitude': this.args['state']['latitude'],
+        'longitude': this.args['state']['longitude'],
+        'city': this.args['state']['city'],
+        'country': this.args['state']['country'],
+      })
     );
 
     return Future<int>.value(response.statusCode);

--- a/lib/operations/perform_url_route.dart
+++ b/lib/operations/perform_url_route.dart
@@ -10,8 +10,8 @@ class PerformUrlRoute extends PlatformOperation {
 
   @override
   Future<int> fallback() async {
-    if (await canLaunch(this.args['url'])) {
-      await launch(this.args['url']);
+    if (await canLaunch(this.args['link'])) {
+      await launch(this.args['link']);
       return 200;
     } else {
       return 404;

--- a/lib/steps/4_complete.dart
+++ b/lib/steps/4_complete.dart
@@ -12,6 +12,6 @@ class Complete extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CompleteForm();
+    return CompleteForm(state: this.state);
   }
 }


### PR DESCRIPTION
This uses the `link` returned from the user request as the dashboard url.

It also cuts down the data sent to the provisioning endpoint to only what's necessary.